### PR TITLE
Tests for 3D to be part of the "Share Viewport" feature.

### DIFF
--- a/tests/desktop/normal/3d/hello_3d.spec.ts
+++ b/tests/desktop/normal/3d/hello_3d.spec.ts
@@ -98,4 +98,39 @@ async function Initialize3D(hv: MobileInterface, page: Page) {
     await page.mouse.up();
     await expect(page).toHaveScreenshot();
   });
+
+  test.only(`[${view.name}] Load State without enable3d in state`, { tag: view.tag }, async ({ page }, info) => {
+    // Firefox in playwright does not allow webgl2 creation.
+    // May need to test manually on a firefox installation, but it is working
+    // in other browsers
+    if (page.context().browser().browserType().name() === "firefox") {
+      test.skip();
+    }
+
+    let hv = HelioviewerFactory.Create(view, page, info) as MobileInterface;
+    const webClientStateRequest = page.waitForRequest('**/getWebClientState');
+    // Set up listener for loading the web client state
+    await page.route('**/getWebClientState**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(loadState3dResponse)
+      });
+    });
+
+    // Load the page, it will load the state we gave it above. Which does
+    // not contain enable3d
+    await hv.Load("/?loadState=something");
+    await webClientStateRequest;
+    await hv.WaitForLoadingComplete();
+
+    // After the page has loaded, we expect enable3d to be false
+    expect(await page.evaluate(() => eval("Helioviewer.userSettings.get('state.enable3d')"))).toBe(false);
+    // 3d button should not be active (no 3d buttons with active css)
+    expect(await page.locator(".js-3d-toggle.active").count()).toBe(0);
+    // No elements should be hidden for 3d
+    expect(await page.locator(".toggle-3d.masked").count()).toBe(0);
+  });
 });
+
+const loadState3dResponse = {"status_code":200,"status_txt":"OK","data":{"date":1735603271000,"imageScale":4.84088176,"centerX":-174.58208757126707,"centerY":-128.78993573759288,"imageLayers":[{"visible":true,"opacity":100,"uiLabels":[{"label":"Observatory","name":"SDO"},{"label":"Instrument","name":"AIA"},{"label":"Measurement","name":"94"}],"difference":0,"diffCount":60,"diffTime":1,"baseDiffTime":"2025-05-13T17:49:32.000Z","sourceId":8,"Observatory":"SDO","Instrument":"AIA","Measurement":"94"}],"eventLayers":{"tree_HEK":{"id":"HEK","visible":true,"markers_visible":true,"labels_visible":true,"layer_available_visible":true,"layers":[]},"tree_CCMC":{"id":"CCMC","visible":true,"markers_visible":true,"labels_visible":true,"layer_available_visible":true,"layers":[]},"tree_RHESSI":{"id":"RHESSI","visible":true,"markers_visible":true,"labels_visible":true,"layer_available_visible":true,"layers":[]}},"celestialBodies":{"soho":[],"stereo_a":[],"stereo_b":[]},"enable3d":false}};

--- a/tests/page_objects/mobile_hv.ts
+++ b/tests/page_objects/mobile_hv.ts
@@ -75,8 +75,8 @@ class HvMobile implements MobileInterface {
   }
 
   /** Navigates to the mobile helioviewer page */
-  async Load() {
-    await this.page.goto("/");
+  async Load(path: string = "/") {
+    await this.page.goto(path);
     await this.page.evaluate(() => console.log(localStorage.getItem("settings")));
     // Wait for the first image layer to be loaded
     await this._WaitForInitialImageLayer();


### PR DESCRIPTION
This adds test cases for:
- existing "states" that don't have the new 3D flag (page will load in 2D)
- loading the page with enable3d = false in the shared state
- loading the page with enable3d = true in the shared state