### PR TITLE
fix regression test 588

### DIFF
--- a/tests/desktop/normal/regression/issue_588.spec.ts
+++ b/tests/desktop/normal/regression/issue_588.spec.ts
@@ -14,6 +14,10 @@ test("Issue 588, special characters in event tree causing to tree to fail", asyn
     // Add a prefix to the title.
     let newJson = await response.json();
 
+    // Filter if Topological Obhect is already on the tree,
+    newJson = newJson.filter((x) => x.name !== "Topological Object");
+
+    // Swap the "Topological Object" with the problem one
     newJson.push({
       name: "Topological Object",
       pin: "TO",


### PR DESCRIPTION
Events mocked during tests filtered for the intended mock part from original request to be able to swap cleanly the new mocked part